### PR TITLE
ENHANCEMENT: add field date to setLatestUnpluggedDate request

### DIFF
--- a/firebase/functions/index.js
+++ b/firebase/functions/index.js
@@ -5,31 +5,33 @@ const moment = require('moment');
 admin.initializeApp(functions.config().firebase);
 
 exports.setLatestUnpluggedImport = functions.https.onRequest((req, res) => {
-  const token = "2e6f9b0d5885b6010f9167787445617f553a735f";
-  const psw = sha1(req.query.psw);
-  if (token == psw){
-    var latestUnpluggedImport;
-    if (req.query.date){
-      latestUnpluggedImport = moment(req.query.date);
-    } else {
-      latestUnpluggedImport = moment(new Date());
-    }
-    if (latestUnpluggedImport.isValid()){
-      latestUnpluggedImport = latestUnpluggedImport.format("YYYY-MM-DD");
-      admin.database().ref('/settings').update({latestUnpluggedImport: latestUnpluggedImport}).then(snapshot => {
-        console.log("Latest Unplugged Import Updated");
-        res.send("ok");
-      }).catch(function(error) {
-        console.log("Error Updating Latest Unplugged Import:", error);
-        res.send("nok");      
-      });
-    } else {
-      console.log("Wrong date format");
-      res.send("nok");
-    }
-    
-  } else {
-    console.log("Wrong psw");
-    res.send("nok");
-  }
+  admin.database().ref('/settings').once('value').then(function(snapshot) {
+    const token = sha1(snapshot.val().password);
+      const psw = sha1(req.query.psw);
+      if (token == psw){
+        var latestUnpluggedImport;
+        if (req.query.date){
+          latestUnpluggedImport = moment(req.query.date);
+        } else {
+          latestUnpluggedImport = moment(new Date());
+        }
+        if (latestUnpluggedImport.isValid()){
+          latestUnpluggedImport = latestUnpluggedImport.format("YYYY-MM-DD");
+          admin.database().ref('/settings').update({latestUnpluggedImport: latestUnpluggedImport}).then(snapshot => {
+            console.log("Latest Unplugged Import Updated");
+            res.send("ok");
+          }).catch(function(error) {
+            console.log("Error Updating Latest Unplugged Import:", error);
+            res.send("nok");      
+          });
+        } else {
+          console.log("Wrong date format");
+          res.send("nok");
+        }
+        
+      } else {
+        console.log("Wrong psw");
+        res.send("nok");
+      }
+  });  
  });

--- a/firebase/functions/index.js
+++ b/firebase/functions/index.js
@@ -1,22 +1,33 @@
 const functions = require('firebase-functions');
 const sha1 = require('sha1');
-const format = require("date-format-lite")
 const admin = require('firebase-admin');
+const moment = require('moment');
 admin.initializeApp(functions.config().firebase);
 
 exports.setLatestUnpluggedImport = functions.https.onRequest((req, res) => {
   const token = "2e6f9b0d5885b6010f9167787445617f553a735f";
-  const pwd = sha1(req.query.pwd);
-  if (token == pwd){
-    var date = new Date();
-    const lastDate = date.format("YYYY-MM-DD");
-    admin.database().ref('/settings').update({latestUnpluggedImport: latestUnpluggedImport}).then(snapshot => {
-      console.log("Latest Unplugged Import Updated");
-      res.send("ok");
-    }).catch(function(error) {
-      console.log("Error Updating Latest Unplugged Import:", error);
-      res.send("nok");      
-    });
+  const psw = sha1(req.query.psw);
+  if (token == psw){
+    var latestUnpluggedImport;
+    if (req.query.date){
+      latestUnpluggedImport = moment(req.query.date);
+    } else {
+      latestUnpluggedImport = moment(new Date());
+    }
+    if (latestUnpluggedImport.isValid()){
+      latestUnpluggedImport = latestUnpluggedImport.format("YYYY-MM-DD");
+      admin.database().ref('/settings').update({latestUnpluggedImport: latestUnpluggedImport}).then(snapshot => {
+        console.log("Latest Unplugged Import Updated");
+        res.send("ok");
+      }).catch(function(error) {
+        console.log("Error Updating Latest Unplugged Import:", error);
+        res.send("nok");      
+      });
+    } else {
+      console.log("Wrong date format");
+      res.send("nok");
+    }
+    
   } else {
     console.log("Wrong psw");
     res.send("nok");

--- a/firebase/functions/package.json
+++ b/firebase/functions/package.json
@@ -5,7 +5,7 @@
     "firebase-admin": "~5.2.1",
     "firebase-functions": "^0.6.2",
     "sha1":"latest",
-    "date-format-lite":"17.7.0"
+    "moment":"2.18.1"
   },
   "private": true
 }


### PR DESCRIPTION
ENHANCEMENT: Closes #50,  add field date to setLatestUnpluggedDate request;

- Added a Date field to setLatestUnpluggedDate cloud function;
URL to call:
    `us-central1-ams-report.cloudfunctions.net/setLatestUnpluggedImport?psw={password}?date={YYYY-MM-DD}`
If the date is not provided the function get the actual date;

- Command to deploy:
   ` firebase deploy --only functions:setLatestUnpluggedImport`

- The function get the password to check from firebase database on settings.password node;