### PR TITLE
UPGRADE: ion2-calendar to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "cordova-plugin-whitelist": "^1.3.1",
     "firebase": "^3.9.0",
     "font-awesome": "^4.7.0",
-    "ion2-calendar": "^2.0.0-beta.1",
+    "ion2-calendar": "^2.0.6",
     "ionic-angular": "^3.6.0",
     "ionic-plugin-keyboard": "^2.2.1",
     "ionicons": "3.0.0",

--- a/src/pages/sites-report/sites-report.ts
+++ b/src/pages/sites-report/sites-report.ts
@@ -179,11 +179,10 @@ export class SitesReportPage {
     );    
   }
 
-
   openCalendar() {
     this.calendarCtrl.openCalendar({
       //from: new Date(),
-      isRadio: false,
+      pickMode:'range',
       isSaveHistory:true,
       canBackwardsSelected: true,
     })


### PR DESCRIPTION
- Upgrade to 2.0.6 Version
- After [2.0.0-beta.5](https://github.com/HsuanXyz/ion2-calendar/releases/tag/2.0.0-beta.5) isRadio param is depreciated in order to add pickMode;
- Updated all isRadio references on project;